### PR TITLE
Add gcc5 patch, terminfo database and widec support

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,8 +5,8 @@ mkdir $PREFIX/lib
 sh ./configure --prefix=$PREFIX \
     --without-debug --without-ada --without-manpages \
     --with-shared --disable-overwrite --enable-termcap \
-    --with-termlib
-
+    --with-termlib \
+    --enable-widec --with-terminfo-dirs=/usr/share/terminfo
 
 make -j$(getconf _NPROCESSORS_ONLN)
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,13 @@ source:
   patches:
     # http://lists.gnu.org/archive/html/bug-ncurses/2011-04/txtkWQqiQvcZe.txt
     - fix.patch
+    - ncurses-5.9-gcc-5.patch
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 5 # [linux64]
+  number: 6 # [linux32]
+  number: 1 # [osx]
   detect_binary_files_with_prefix: true
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ test:
     - run_test.sh         # [osx]
     - run_test.py         # [osx]
   commands:
-    - exit $(test -f ${PREFIX}/lib/libncurses.a)
+    - exit $(test -f ${PREFIX}/lib/libncursesw.a)
     - exit $(test -f ${PREFIX}/lib/libtinfo.a)
     - exit $(test -f ${PREFIX}/lib/libform.a)
     - exit $(test -f ${PREFIX}/lib/libmenu.a)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 5 # [linux64]
-  number: 6 # [linux32]
-  number: 1 # [osx]
+  number: 1
   detect_binary_files_with_prefix: true
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,10 +24,10 @@ test:
     - run_test.py         # [osx]
   commands:
     - exit $(test -f ${PREFIX}/lib/libncursesw.a)
-    - exit $(test -f ${PREFIX}/lib/libtinfo.a)
-    - exit $(test -f ${PREFIX}/lib/libform.a)
-    - exit $(test -f ${PREFIX}/lib/libmenu.a)
-    - exit $(test -f ${PREFIX}/lib/libpanel.a)
+    - exit $(test -f ${PREFIX}/lib/libtinfow.a)
+    - exit $(test -f ${PREFIX}/lib/libformw.a)
+    - exit $(test -f ${PREFIX}/lib/libmenuw.a)
+    - exit $(test -f ${PREFIX}/lib/libpanelw.a)
 
     - bash run_test.sh    # [osx]
     - python run_test.py  # [osx]

--- a/recipe/ncurses-5.9-gcc-5.patch
+++ b/recipe/ncurses-5.9-gcc-5.patch
@@ -1,0 +1,47 @@
+from https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/sys-libs/ncurses/files/ncurses-5.9-gcc-5.patch?revision=1.1
+https://bugs.gentoo.org/545114
+
+extracted from the upstream change (which had many unrelated commits in one)
+
+From 97bb4678dc03e753290b39bbff30ba2825df9517 Mon Sep 17 00:00:00 2001
+From: "Thomas E. Dickey" <dickey@invisible-island.net>
+Date: Sun, 7 Dec 2014 03:10:09 +0000
+Subject: [PATCH] ncurses 5.9 - patch 20141206
+
++ modify MKlib_gen.sh to work around change in development version of
+  gcc introduced here:
+	  https://gcc.gnu.org/ml/gcc-patches/2014-06/msg02185.html
+	  https://gcc.gnu.org/ml/gcc-patches/2014-07/msg00236.html
+  (reports by Marcus Shawcroft, Maohui Lei).
+
+diff --git a/ncurses/base/MKlib_gen.sh b/ncurses/base/MKlib_gen.sh
+index d8cc3c9..b91398c 100755
+--- ncurses/base/MKlib_gen.sh
++++ ncurses/base/MKlib_gen.sh
+@@ -474,11 +474,22 @@ sed -n -f $ED1 \
+	-e 's/gen_$//' \
+	-e 's/  / /g' >>$TMP
+
++cat >$ED1 <<EOF
++s/  / /g
++s/^ //
++s/ $//
++s/P_NCURSES_BOOL/NCURSES_BOOL/g
++EOF
++
++# A patch discussed here:
++#	https://gcc.gnu.org/ml/gcc-patches/2014-06/msg02185.html
++# introduces spurious #line markers.  Work around that by ignoring the system's
++# attempt to define "bool" and using our own symbol here.
++sed -e 's/bool/P_NCURSES_BOOL/g' $TMP > $ED2
++cat $ED2 >$TMP
++
+ $preprocessor $TMP 2>/dev/null \
+-| sed \
+-	-e 's/  / /g' \
+-	-e 's/^ //' \
+-	-e 's/_Bool/NCURSES_BOOL/g' \
++| sed -f $ED1 \
+ | $AWK -f $AW2 \
+ | sed -f $ED3 \
+ | sed \


### PR DESCRIPTION
This should fix ContinuumIO/anaconda-issues#455

* add widec support
* add path for terminfo database
* add fix for compiling with gcc 5

If there are other common locations for `terminfo` databases other than `/usr/share/terminfo` they should be added as well.