### PR TITLE
Do not place header files in subdirectory

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@ mkdir $PREFIX/lib
 sh ./configure --prefix=$PREFIX \
     --without-debug --without-ada --without-manpages \
     --with-shared --disable-overwrite --enable-termcap \
-    --with-termlib \
+    --with-termlib --includedir=$PREFIX/include \
     --enable-widec --with-terminfo-dirs=/usr/share/terminfo
 
 make -j$(getconf _NPROCESSORS_ONLN)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,3 +41,4 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - jjhelmus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
 test:


### PR DESCRIPTION
Use the --includedir flag in configure to specify that the headers should be
installed in $PREFIX/include not the default $PREFIX/include/ncursesw/

closes #3