### PR TITLE
Bump build number to rebuild Linux

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
 test:


### PR DESCRIPTION
Somehow I am unable to unarchive the Linux package. The Mac one works fine though. So, here we bump the build number so we can get another release on Linux. Hopefully, this one can be unarchived correctly.