### PR TITLE
Use symlinks

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,6 +9,7 @@ sh ./configure \
 	--without-manpages \
 	--with-shared \
 	--disable-overwrite \
+	--enable-symlinks \
 	--enable-termcap \
 	--with-termlib \
 	--enable-widec \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,11 +2,17 @@
 
 mkdir $PREFIX/lib
 
-sh ./configure --prefix=$PREFIX \
-    --without-debug --without-ada --without-manpages \
-    --with-shared --disable-overwrite --enable-termcap \
-    --with-termlib \
-    --enable-widec --with-terminfo-dirs=/usr/share/terminfo
+sh ./configure \
+	--prefix=$PREFIX \
+	--without-debug \
+	--without-ada \
+	--without-manpages \
+	--with-shared \
+	--disable-overwrite \
+	--enable-termcap \
+	--with-termlib \
+	--enable-widec \
+	--with-terminfo-dirs=/usr/share/terminfo
 
 make -j$(getconf _NPROCESSORS_ONLN)
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 2
+  number: 3
   detect_binary_files_with_prefix: true
 
 test:


### PR DESCRIPTION
Appears hardlinks are being used to some system utilities. That is really not a nice thing for a conda package to do. So, we have enabled symlinks.