### PR TITLE
Symlink includes

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,8 +3,14 @@
 mkdir $PREFIX/lib
 
 
-for USE_WIDEC in "" "--enable-widec"
+for USE_WIDEC in false true;
 do
+    WIDEC_OPT=""
+    if [ "${USE_WIDEC}" = true ];
+    then
+        WIDEC_OPT="--enable-widec"
+    fi
+
     sh ./configure \
 	    --prefix=$PREFIX \
 	    --without-debug \
@@ -15,8 +21,22 @@ do
 	    --enable-symlinks \
 	    --enable-termcap \
 	    --with-termlib \
-	    $USE_WIDEC \
+	    $WIDEC_OPT \
 	    --with-terminfo-dirs=/usr/share/terminfo
     make
     make install
+
+    # Provide headers in `$PREFIX/include` and
+    # symlink them in `$PREFIX/include/ncurses`
+    # and in `$PREFIX/include/ncursesw`.
+    HEADERS_DIR="${PREFIX}/include/ncurses"
+    if [ "${USE_WIDEC}" = true ];
+    then
+        HEADERS_DIR="${PREFIX}/include/ncursesw"
+    fi
+    for HEADER in $(ls $HEADERS_DIR);
+    do
+        mv "${HEADERS_DIR}/${HEADER}" "${PREFIX}/include/${HEADER}"
+        ln -s "${PREFIX}/include/${HEADER}" "${HEADERS_DIR}/${HEADER}"
+    done
 done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-mkdir $PREFIX/lib
-
 
 for USE_WIDEC in false true;
 do

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@ mkdir $PREFIX/lib
 sh ./configure --prefix=$PREFIX \
     --without-debug --without-ada --without-manpages \
     --with-shared --disable-overwrite --enable-termcap \
-    --with-termlib \
+    --with-termlib --includedir=$PREFIX/include \
     --enable-widec --with-terminfo-dirs=/usr/share/terminfo
 
 make -j$(getconf _NPROCESSORS_ONLN)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,3 +41,4 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - jjhelmus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,16 +24,24 @@ test:
     - run_test.sh         # [osx]
     - run_test.py         # [osx]
   commands:
-    - test -f ${PREFIX}/lib/libncurses.a
-    - test -f ${PREFIX}/lib/libtinfo.a
-    - test -f ${PREFIX}/lib/libform.a
-    - test -f ${PREFIX}/lib/libmenu.a
-    - test -f ${PREFIX}/lib/libpanel.a
-    - test -f ${PREFIX}/lib/libncursesw.a
-    - test -f ${PREFIX}/lib/libtinfow.a
-    - test -f ${PREFIX}/lib/libformw.a
-    - test -f ${PREFIX}/lib/libmenuw.a
-    - test -f ${PREFIX}/lib/libpanelw.a
+    # Test libraries
+    {% set ncurses_libraries = [
+        "libncurses",
+        "libtinfo",
+        "libform",
+        "libmenu",
+        "libpanel",
+        "libncursesw",
+        "libtinfow",
+        "libformw",
+        "libmenuw",
+        "libpanelw"
+    ] %}
+    {% for each_ncurses_library in ncurses_libraries %}
+    - test -f ${PREFIX}/lib/{{ each_ncurses_library }}.a
+    - test -f ${PREFIX}/lib/{{ each_ncurses_library }}.dylib   # [osx]
+    - test -f ${PREFIX}/lib/{{ each_ncurses_library }}.so      # [linux]
+    {% endfor %}
 
     # Test include directories
     - test -d ${PREFIX}/include/ncurses

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,40 @@ test:
     - test -f ${PREFIX}/lib/libmenuw.a
     - test -f ${PREFIX}/lib/libpanelw.a
 
+    # Test include directories
+    - test -d ${PREFIX}/include/ncurses
+    - test -d ${PREFIX}/include/ncursesw
+
+    # Test headers
+    {% set ncurses_headers = [
+        "curses.h",
+        "cursesapp.h",
+        "cursesf.h",
+        "cursesm.h",
+        "cursesp.h",
+        "cursesw.h",
+        "cursslk.h",
+        "eti.h",
+        "etip.h",
+        "form.h",
+        "menu.h",
+        "nc_tparm.h",
+        "ncurses.h",
+        "ncurses_dll.h",
+        "panel.h",
+        "term.h",
+        "term_entry.h",
+        "termcap.h",
+        "tic.h",
+        "unctrl.h"
+    ] %}
+    {% for each_ncurses_header in ncurses_headers %}
+    - test -L ${PREFIX}/include/ncurses/{{ each_ncurses_header }}
+    - test -L ${PREFIX}/include/ncursesw/{{ each_ncurses_header }}
+    - test -f ${PREFIX}/include/{{ each_ncurses_header }}
+    {% endfor %}
+
+    # Usage tests
     - bash run_test.sh    # [osx]
     - python run_test.py  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 4
+  number: 5
   detect_binary_files_with_prefix: true
 
 test:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/ncurses-feedstock/issues/3
Closes https://github.com/conda-forge/ncurses-feedstock/pull/4

Different Linux variants handle the issue of where to place ncurses differently. Debian apparently puts them all in `include` in a flat manner (no subdirectories). Enterprise Linux appears to also put them in a flat manner, but symlinks the headers from their usual locations `include/ncurses` and `include/ncursesw` to the flat structure. This seems to be the best of both worlds. People expecting to do `#include <ncurses/curses.h>` for instances can still do this with this strategy, but it also allows for things like `#include <curses.h>`. That way applications expecting to find them in `${PREFIX}/include/ncursues` and `${PREFIX}/include/ncursuesw` can find them, but they are also available in `${PREFIX}/include` for those that prefer to find them there. Note that symlinking widec and and non-widec includes to the same includes is ok because they are [source compatible]( http://www.linuxfromscratch.org/lfs/view/6.5/chapter06/ncurses.html ).

I have absorbed PR ( https://github.com/conda-forge/ncurses-feedstock/pull/4 ) into the history here, but have changed how it works to better solve this problem as explained above. Feedback welcome. Thanks @jjhelmus for raising this point.

cc @pelson @jjhelmus 