### PR TITLE
WIP: Combine `libtinfo` with `libncurses`

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
 
+if [[ `uname` == 'Darwin' ]];
+then
+    DYLIB_EXT=dylib
+else
+    DYLIB_EXT=so
+fi
+
 for USE_WIDEC in false true;
 do
     WIDEC_OPT=""
@@ -20,13 +27,22 @@ do
 	    --enable-symlinks \
 	    --enable-termcap \
 	    --enable-pc-files \
-	    --with-termlib \
 	    $WIDEC_OPT \
 	    --with-terminfo-dirs=/usr/share/terminfo
     make
     make install
     make clean
     make distclean
+
+    # Provide tinfo files as links to ncurses files.
+    LIB_LETTER=""
+    if [ "${USE_WIDEC}" = true ];
+    then
+        LIB_LETTER="w"
+    fi
+    ln -s "${PREFIX}/lib/libncurses${LIB_LETTER}.a" "${PREFIX}/lib/libtinfo${LIB_LETTER}.a"
+    ln -s "${PREFIX}/lib/libncurses${LIB_LETTER}.${DYLIB_EXT}" "${PREFIX}/lib/libtinfo${LIB_LETTER}.${DYLIB_EXT}"
+    ln -s "${PREFIX}/lib/pkgconfig/ncurses${LIB_LETTER}.pc" "${PREFIX}/lib/pkgconfig/tinfo${LIB_LETTER}.pc"
 
     # Provide headers in `$PREFIX/include` and
     # symlink them in `$PREFIX/include/ncurses`

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 7
+  number: 8
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -46,6 +46,9 @@ test:
     - test -f ${PREFIX}/lib/{{ each_ncurses_library }}.so       # [linux]
     - test -f ${PREFIX}/lib/{{ each_ncurses_library }}w.so      # [linux]
     {% endfor %}
+    - test -L ${PREFIX}/lib/libtinfo.a
+    - test -L ${PREFIX}/lib/libtinfo.dylib                     # [osx]
+    - test -L ${PREFIX}/lib/libtinfo.so                        # [linux]
 
     # Test include directories
     - test -d ${PREFIX}/include/ncurses
@@ -95,10 +98,24 @@ test:
     {% endfor %}
 
     # Test ncurses library arguments.
-    - pkg-config ncursesw --libs | grep "^-L${PREFIX}/lib -lncursesw -ltinfow $"
-    - pkg-config tinfow --libs | grep "^-L${PREFIX}/lib -ltinfow $"
-    - pkg-config ncurses --libs | grep "^-L${PREFIX}/lib -lncurses -ltinfo $"
-    - pkg-config tinfo --libs | grep "^-L${PREFIX}/lib -ltinfo $"
+    - pkg-config ncursesw --libs | grep "^-L${PREFIX}/lib -lncursesw $"
+    - pkg-config tinfow --libs | grep "^-L${PREFIX}/lib -lncursesw $"
+    - pkg-config ncurses --libs | grep "^-L${PREFIX}/lib -lncurses $"
+    - pkg-config tinfo --libs | grep "^-L${PREFIX}/lib -lncurses $"
+
+    # Test for tinfo symbols.
+    {% set tinfo_symbols = [
+        "cbreak",
+        "keypad",
+        "stdscr"
+    ] %}
+
+    {% for each_tinfo_symbol in tinfo_symbols %}
+    - nm "${PREFIX}/lib/libncurses.so" | grep '.* {{ each_tinfo_symbol }}$'       # [linux]
+    - nm "${PREFIX}/lib/libncursesw.so" | grep '.* {{ each_tinfo_symbol }}$'      # [linux]
+    - nm "${PREFIX}/lib/libncurses.dylib" | grep '.* _{{ each_tinfo_symbol }}$'   # [osx]
+    - nm "${PREFIX}/lib/libncursesw.dylib" | grep '.* _{{ each_tinfo_symbol }}$'  # [osx]
+    {% endfor %}
 
     # Usage tests
     - bash run_test.sh    # [osx]


### PR DESCRIPTION
Needs https://github.com/conda-forge/ncurses-feedstock/pull/12 and https://github.com/conda-forge/ncurses-feedstock/pull/11 to be merged first.

Fixes https://github.com/conda-forge/ncurses-feedstock/issues/9

Some users expect to find all of `libtinfo`'s symbols in `libncurses`. While not all builds of `libncurses` do this and the trend has been to have a separate `libtinfo`, this puts them back together in the same library. However, it does provides symlinks named after the `libtinfo` libraries that point back to `libncurses`. This way programs that expect to link to `libtinfo` still can, but will get those symbols from `libncurses`. Part of the reason this has been opted for is `defaults` does the same thing. We have included some tests to verify that *some* of the `libtinfo` symbols are in `libncurses`, which should be sufficient in verifying this works.

After this is merged, anything built with `ncurses` support is going to have to be rebuilt as this will break those packages. Currently, that is just `erlang`, which needs to be pinned anyways ( https://github.com/conda-forge/erlang-feedstock/issues/5 ). Though it would be good to get this in before our own `python` is released so that we will have some time to test this new configuration with that build and release it using this new configuration. Thus, this is a good time to make this break if we are going to do it.

xref: https://github.com/bioconda/bioconda-recipes/pull/1391

cc @pelson @ocefpaf @msarahan @jjhelmus @scopatz @cel4 @croth1 @johanneskoester