### PR TITLE
Cleanup recipe

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,6 +23,8 @@ do
 	    --with-terminfo-dirs=/usr/share/terminfo
     make
     make install
+    make clean
+    make distclean
 
     # Provide headers in `$PREFIX/include` and
     # symlink them in `$PREFIX/include/ncurses`

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,16 +31,14 @@ test:
         "libform",
         "libmenu",
         "libpanel",
-        "libncursesw",
-        "libtinfow",
-        "libformw",
-        "libmenuw",
-        "libpanelw"
     ] %}
     {% for each_ncurses_library in ncurses_libraries %}
     - test -f ${PREFIX}/lib/{{ each_ncurses_library }}.a
-    - test -f ${PREFIX}/lib/{{ each_ncurses_library }}.dylib   # [osx]
-    - test -f ${PREFIX}/lib/{{ each_ncurses_library }}.so      # [linux]
+    - test -f ${PREFIX}/lib/{{ each_ncurses_library }}w.a
+    - test -f ${PREFIX}/lib/{{ each_ncurses_library }}.dylib    # [osx]
+    - test -f ${PREFIX}/lib/{{ each_ncurses_library }}w.dylib   # [osx]
+    - test -f ${PREFIX}/lib/{{ each_ncurses_library }}.so       # [linux]
+    - test -f ${PREFIX}/lib/{{ each_ncurses_library }}w.so      # [linux]
     {% endfor %}
 
     # Test include directories

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 5
+  number: 6
   detect_binary_files_with_prefix: true
 
 test:


### PR DESCRIPTION
Does a bit of refactoring in the tests to streamline the handling of widec and non-widec cases a bit more. Also, adds a clean step at the end of each build. As there may be some contamination between builds (though this is not expected), we have upped the build number to make sure we get a fresh build with this cleaning step. 