### PR TITLE
Use the `toolchain` to build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,11 +16,12 @@ source:
 
 build:
   skip: true  # [win]
-  number: 7
+  number: 8
   detect_binary_files_with_prefix: true
 
 requirements:
   build:
+    - toolchain
     - pkg-config
 
 test:


### PR DESCRIPTION
There is some C++ code in `ncurses`. This tries to use the `toolchain` to build so that it uses `clang++`/`libc++` for the C++ code.

Should note that `libncurses++` is a very strange library in that it comes as static only. As a result, it is pretty hard to determine what it was linked with C++ library wise. This should make it conformant.