### PR TITLE
Drop `with-terminfo-dirs`

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,8 +21,7 @@ do
 	    --enable-termcap \
 	    --enable-pc-files \
 	    --with-termlib \
-	    $WIDEC_OPT \
-	    --with-terminfo-dirs=/usr/share/terminfo
+	    $WIDEC_OPT
     make
     make install
     make clean

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 8
+  number: 9
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/ncurses-feedstock/issues/17

Uses the default value for `--with-terminfo-dirs`, which ends up being `DATADIR/terminfo` or with default `DATADIR` is `PREFIX/share/terminfo`. This matches more closely to what we want to ensure the database can be distributed. Should fix some issues in more minimal Docker image environments.