### PR TITLE
Revert "remove case-sensitive duplicates of terminfo symlinks"

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -81,24 +81,3 @@ for LIB_NAME in libncurses libtinfo libform libmenu libpanel; do
     rm ${PREFIX}/lib/${LIB_NAME}.a
     rm ${PREFIX}/lib/${LIB_NAME}w.a
 done
-
-# delete case-sensitive spellings of terminals, at least on linux-64, which can
-# easily get installed on case-insensitive filesystems (e.g. through WSL), see #73
-if [[ "$target_platform" == "linux-64" ]]; then
-    # all terminals under /P are duplicates of those in /p
-    rm -rf ${PREFIX}/share/terminfo/P
-    # rest
-    declare -a TERM_NAME=(
-        "2/2621A"
-        "E/Eterm"
-        "E/Eterm-color"
-        "h/hp2621A"
-        "h/hp70092A"
-        "L/LFT-PC850"
-        "N/NCR260VT300WPP"
-        "N/NCRVT100WPP"
-    )
-    for term in "${TERM_NAME[@]}"; do
-        rm ${PREFIX}/share/terminfo/${term}
-    done
-fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   run_exports:
     # pretty good compat within major version
     #  https://abi-laboratory.pro/tracker/timeline/ncurses/
@@ -116,9 +116,6 @@ test:
     - pkg-config tinfo --libs | grep "^-L${PREFIX}/lib .*-ltinfo$"
     - pkg-config ncursesw --libs | grep "^-L${PREFIX}/lib .*-lncursesw -ltinfow$"
     - pkg-config tinfow --libs | grep "^-L${PREFIX}/lib .*-ltinfow$"
-
-    # test absence of terminfo symlinks that require case-sensitivity (see #73)
-    - test ! -d ${PREFIX}/share/terminfo/P  # [linux64]
 
     # Usage tests
     # - bash run_test.sh    # [osx]


### PR DESCRIPTION
This reverts commit 689e997d5019a20bf34199c2a9f96ccde9d8c521.

As requested in #73

CC @mbargull 