### PR TITLE
Rebuild with new build tic program in ncurses to fix cross compilation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 2
+  number: 3
   run_exports:
     # pretty good compat within major version
     #  https://abi-laboratory.pro/tracker/timeline/ncurses/
@@ -105,6 +105,8 @@ test:
     - test -f ${PREFIX}/lib/pkgconfig/{{ each_ncurses_pc_file }}w.pc
     - cat ${PREFIX}/lib/pkgconfig/{{ each_ncurses_pc_file }}w.pc
     {% endfor %}
+
+    - test -f $PREFIX/share/terminfo/78/xterm-256color
 
     # Test ncurses library arguments.
     - pkg-config ncurses --libs


### PR DESCRIPTION
Note that we have a

```
requirements:
  build:
    - ncurses   # [build_platform != target_platform]
```

to use tic, but for linux-aarch64 and linux-ppc64le, we used tic that was built with mixed cases enabled. rebuilding should fix this.

Fixes the error in https://github.com/conda-forge/python-feedstock/pull/770#issuecomment-2621505383